### PR TITLE
Set static physics on BaseStructureDisable{ToolUse,Anchoring}

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/base_structure.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/base_structure.yml
@@ -4,6 +4,8 @@
   components:
   - type: Transform
     anchored: true
+  - type: Physics
+    bodyType: Static
   - type: DisableToolUse
     anchoring: true
     prying: true
@@ -23,6 +25,8 @@
   components:
   - type: Transform
     anchored: true
+  - type: Physics
+    bodyType: Static
   - type: DisableToolUse
     anchoring: true
 


### PR DESCRIPTION
See title. Fixes workflow errors. Probably.